### PR TITLE
Improve PDF manager UI with drag-and-drop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# PDF Extractor Flask App
+# Gestor de PDFs
 
-Este proyecto permite cargar múltiples archivos PDF, extraer de ellos la fecha, nombre, cargo y empresa mediante expresiones regulares y generar un archivo Excel con los resultados.
+Esta aplicación Flask permite subir múltiples archivos PDF y procesarlos para extraer información relevante. Utiliza un diseño moderno con Bootstrap 5 y ofrece carga de archivos mediante arrastrar y soltar.
 
 ## Instalación
 
@@ -26,6 +26,11 @@ flask run
 
 La aplicación estará disponible en `http://127.0.0.1:5000/`.
 
+Dependencias principales:
+- Flask y Flask-WTF
+- pdfplumber para leer PDFs
+- pandas y openpyxl para generar Excel
+
 ## Configuración
 
 - `SECRET_KEY`: clave secreta para Flask (opcional en variables de entorno).
@@ -34,3 +39,9 @@ La aplicación estará disponible en `http://127.0.0.1:5000/`.
 ## Procesamiento asíncrono (opcional)
 
 Si el volumen de PDFs es grande, se recomienda integrar Celery y Redis para manejar las tareas en segundo plano.
+
+## Uso
+
+1. Abre la página principal y arrastra varios PDFs al área azul.
+2. Verás una lista previa de los archivos antes de enviarlos.
+3. Al terminar el procesamiento se mostrará un enlace para descargar el Excel.

--- a/app/services/storage.py
+++ b/app/services/storage.py
@@ -1,0 +1,29 @@
+"""Service for handling temporary storage of uploaded files."""
+from datetime import datetime
+import os
+from flask import current_app
+from werkzeug.utils import secure_filename
+
+
+def save_upload(file_storage):
+    """Save uploaded file to the configured UPLOAD_FOLDER and return metadata."""
+    upload_dir = current_app.config["UPLOAD_FOLDER"]
+    os.makedirs(upload_dir, exist_ok=True)
+    filename = secure_filename(file_storage.filename)
+    path = os.path.join(upload_dir, filename)
+    file_storage.save(path)
+    return {"name": filename, "path": path, "date": datetime.utcnow()}
+
+
+def list_uploaded_files():
+    """Return list of uploaded PDF files with upload timestamp."""
+    upload_dir = current_app.config["UPLOAD_FOLDER"]
+    if not os.path.isdir(upload_dir):
+        return []
+    files = []
+    for name in os.listdir(upload_dir):
+        if name.lower().endswith(".pdf"):
+            path = os.path.join(upload_dir, name)
+            timestamp = datetime.fromtimestamp(os.path.getmtime(path))
+            files.append({"name": name, "date": timestamp})
+    return sorted(files, key=lambda x: x["date"], reverse=True)

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>{% block title %}PDF Extractor{% endblock %}</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" integrity="sha384-9ndCyUa6mY5rL1W6kCQbC4h6vG4lFE8eZY9d3zt0xFDAPbE6CktvhqDH5Wld/5GX" crossorigin="anonymous">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
 </head>
 <body>
@@ -18,5 +19,7 @@
     {% endwith %}
     {% block content %}{% endblock %}
   </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-ENjdO4Dr2bkBIFxQpeoZL8MBRjZ8J1L6AJ4pHDebnHN2DFYcCI1dA2VQ0XU8N/Iw" crossorigin="anonymous"></script>
+  <script src="{{ url_for('static', filename='js/app.js') }}"></script>
 </body>
 </html>

--- a/app/templates/result.html
+++ b/app/templates/result.html
@@ -3,6 +3,9 @@
 {% block title %}Resultado{% endblock %}
 
 {% block content %}
-  <h1>Resultado</h1>
-  <p>Descargar Excel generado: <a href="{{ url_for('uploads.download_file', filename=excel_file) }}">{{ excel_file }}</a></p>
+  <h1 class="my-4">Resultado</h1>
+  <p>
+    Descargar Excel generado:
+    <a class="btn btn-primary" href="{{ url_for('uploads.download_file', filename=excel_file) }}">{{ excel_file }}</a>
+  </p>
 {% endblock %}

--- a/app/templates/upload.html
+++ b/app/templates/upload.html
@@ -1,11 +1,22 @@
 {% extends 'base.html' %}
 
-{% block title %}Upload PDFs{% endblock %}
+{% block title %}Gestionar PDFs{% endblock %}
 
 {% block content %}
-  <h1>Upload PDF files</h1>
-  <form method="post" enctype="multipart/form-data">
-    <input type="file" name="files" multiple required>
-    <button type="submit">Procesar</button>
-  </form>
+<h1 class="my-4">Subir documentos</h1>
+<div id="drop-area" class="mb-3">
+  Arrastra y suelta los archivos o haz clic para seleccionarlos
+</div>
+<form id="upload-form" method="post" enctype="multipart/form-data">
+  <input id="file-input" type="file" name="files" multiple hidden required>
+  <ul id="file-list" class="file-preview list-unstyled"></ul>
+  <button type="submit" class="btn btn-primary mt-3">Procesar</button>
+</form>
+
+<h2 class="mt-5">Documentos (<span id="docs-count">{{ files|length }}</span>)</h2>
+<ul id="docs-container" class="list-unstyled">
+  {% for f in files %}
+  <li>{{ f.name }} - {{ f.date.strftime('%Y-%m-%d %H:%M') }}</li>
+  {% endfor %}
+</ul>
 {% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask
 pdfplumber
 pandas
 openpyxl
+Flask-WTF

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,3 +1,43 @@
-body { font-family: Arial, sans-serif; margin: 20px; }
-.container { max-width: 600px; margin: auto; }
-.flashes { color: red; }
+body {
+  font-family: Arial, sans-serif;
+  margin: 20px;
+  background-color: #f8f9fa;
+}
+
+.container {
+  max-width: 700px;
+  margin: auto;
+}
+
+.btn-primary {
+  background-color: #0d6efd;
+  border-color: #0d6efd;
+  border-radius: 0.3rem;
+}
+
+.btn-primary:hover {
+  background-color: #0b5ed7;
+  border-color: #0a58ca;
+}
+
+#drop-area {
+  border: 2px dashed #0d6efd;
+  padding: 40px;
+  text-align: center;
+  cursor: pointer;
+  color: #0d6efd;
+  border-radius: 0.5rem;
+  transition: background-color 0.2s ease;
+}
+
+#drop-area.active {
+  background-color: #e2e6ea;
+}
+
+.file-preview {
+  margin-top: 1rem;
+}
+
+.flashes {
+  color: red;
+}

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,0 +1,75 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const dropArea = document.getElementById('drop-area');
+  const fileInput = document.getElementById('file-input');
+  const fileList = document.getElementById('file-list');
+  const uploadForm = document.getElementById('upload-form');
+  const docsContainer = document.getElementById('docs-container');
+
+  function fetchFiles() {
+    fetch('/files')
+      .then(r => r.json())
+      .then(files => {
+        docsContainer.innerHTML = '';
+        const count = document.getElementById('docs-count');
+        count.textContent = files.length;
+        files.forEach(f => {
+          const li = document.createElement('li');
+          const date = new Date(f.date).toLocaleString();
+          li.textContent = `${f.name} - ${date}`;
+          docsContainer.appendChild(li);
+        });
+      });
+  }
+
+  if (dropArea) {
+    ['dragenter', 'dragover'].forEach(evt => {
+      dropArea.addEventListener(evt, e => {
+        e.preventDefault();
+        dropArea.classList.add('active');
+      });
+    });
+
+    ['dragleave', 'drop'].forEach(evt => {
+      dropArea.addEventListener(evt, e => {
+        e.preventDefault();
+        dropArea.classList.remove('active');
+      });
+    });
+
+    dropArea.addEventListener('drop', e => {
+      const files = e.dataTransfer.files;
+      fileInput.files = files;
+      showSelectedFiles();
+    });
+
+    dropArea.addEventListener('click', () => fileInput.click());
+  }
+
+  function showSelectedFiles() {
+    fileList.innerHTML = '';
+    Array.from(fileInput.files).forEach(f => {
+      const li = document.createElement('li');
+      li.textContent = f.name;
+      fileList.appendChild(li);
+    });
+  }
+
+  if (fileInput) {
+    fileInput.addEventListener('change', showSelectedFiles);
+  }
+
+  if (uploadForm) {
+    uploadForm.addEventListener('submit', e => {
+      e.preventDefault();
+      const formData = new FormData(uploadForm);
+      fetch('/', { method: 'POST', body: formData })
+        .then(resp => resp.text())
+        .then(html => {
+          document.body.innerHTML = html;
+          fetchFiles();
+        });
+    });
+  }
+
+  fetchFiles();
+});


### PR DESCRIPTION
## Summary
- customize styling with Bootstrap
- implement drag & drop PDF uploads
- list uploaded files and provide count via API
- add storage service
- document usage and dependencies

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688838d8f0688324a175de9ff897c7e5