### PR TITLE
Fix upload threading context

### DIFF
--- a/app/blueprints/uploads.py
+++ b/app/blueprints/uploads.py
@@ -22,15 +22,22 @@ def upload_files():
             flash('No files selected')
             return redirect(request.url)
 
+        upload_dir = current_app.config["UPLOAD_FOLDER"]
+        invalid_count = 0
+
         def _process(file):
+            nonlocal invalid_count
             if not validate_file(file):
-                flash(f'Invalid file: {file.filename}')
+                invalid_count += 1
                 return None
-            info = save_upload(file)
+            info = save_upload(file, upload_dir=upload_dir)
             return extract_fields_from_pdf(info["path"])
 
         with ThreadPoolExecutor() as executor:
             results = [r for r in executor.map(_process, files) if r]
+
+        if invalid_count:
+            flash(f'{invalid_count} invalid file(s) skipped')
 
         if not results:
             flash('No valid PDFs processed')

--- a/app/services/storage.py
+++ b/app/services/storage.py
@@ -5,9 +5,13 @@ from flask import current_app
 from werkzeug.utils import secure_filename
 
 
-def save_upload(file_storage):
-    """Save uploaded file to the configured UPLOAD_FOLDER and return metadata."""
-    upload_dir = current_app.config["UPLOAD_FOLDER"]
+def save_upload(file_storage, upload_dir=None):
+    """Save uploaded file to the configured ``UPLOAD_FOLDER`` and return metadata.
+
+    When called outside an application context, ``upload_dir`` must be provided.
+    """
+    if upload_dir is None:
+        upload_dir = current_app.config["UPLOAD_FOLDER"]
     os.makedirs(upload_dir, exist_ok=True)
     filename = secure_filename(file_storage.filename)
     path = os.path.join(upload_dir, filename)


### PR DESCRIPTION
## Summary
- allow uploads to be processed in threads without app context
- flash a message when invalid files are skipped

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888448526e483248e76dda65d979003